### PR TITLE
Add optional lambdaZipPath arg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,14 @@ type RemotionLambdaConfig = {
    * @default 2048
    */
   memorySizeInMb?: number;
+  
+  /**
+   * The path to the lambda zip file.
+   *
+   * @default (remotionlambda-arm64.zip in node_modules/@remotion/lambda)
+   *
+   */
+  lambdaZipPath?: string;
 };
 
 /**
@@ -195,7 +203,7 @@ export class RemotionLambda extends pulumi.ComponentResource {
       { parent: this },
     );
 
-    const zipPath = path.join(
+    const zipPath = args.lambdaZipPath || path.join(
       process.cwd(),
       "node_modules",
       "@remotion/lambda",


### PR DESCRIPTION
## Motivation
When using this package in a monorepo, errors occur whilst locating the remotionlambda-arm64.zip archive. This is because the @remotion/lambda package might be hoisted a few directories up compared to the expected location.

## Change
This change allows the user to specify a path to use for the remotionlambda file.

```js
    const zipPath = args.lambdaZipPath || path.join(
      process.cwd(),
      "node_modules",
      "@remotion/lambda",
      "remotionlambda-arm64.zip",
    );
```